### PR TITLE
Pixel IMS 5G 1.0.6 - Small bug fixes

### DIFF
--- a/.github/release-notes/v1.0.6.md
+++ b/.github/release-notes/v1.0.6.md
@@ -1,0 +1,12 @@
+## Pixel IMS 5G 1.0.6 - Small bug fixes
+
+This is a **small bug-fix update** for Root SIM configuration persistence.
+
+- **Stable Root SIM controls:** VoNR, VoWiFi, enhanced-data-icon, and other SIM Config choices no longer replace one another when changed separately.
+- **Persistent per-SIM profiles:** Root mode saves one complete CarrierConfig profile for each SIM and restores it after reboot, user unlock, app update, or Root service reconnect.
+- **Safe reset:** Restore Google defaults also removes the saved Root profile.
+- **Clear Shizuku behavior:** Shizuku settings remain session-only and may reset after reboot.
+
+Validated on a rooted Pixel 7 Pro running Android 17. The saved VoNR profile survived a physical reboot and was reapplied as one merged CarrierConfig bundle.
+
+Existing installations using `com.nirmala.pixel5gims` can update normally without uninstalling.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,21 @@ An experimental root- or Shizuku-powered IMS and radio configuration app for Goo
 
 Android application ID: `com.nirmala.pixel5gims`.
 
-Current public release: `1.0.5` (`v1.0.5`). This is a **small update** focused on
-the VoLTE fix, live IMS status indicators, and Root VoWiFi diagnostics. The one-time uninstall/reinstall notice applies specifically
+Current public release: `1.0.6` (`v1.0.6`). This is a **small bug-fix update** focused on
+keeping Root SIM Config choices stable across changes and reboots. The one-time uninstall/reinstall notice applies specifically
 to version `0.12.6`, where the application ID changed. Existing `0.12.6` installations
 can update normally to later versions.
 
 ## Changelog
+
+### [1.0.6](https://github.com/barrylk/Pixel-IMS-5G/releases/tag/v1.0.6) - small bug fixes
+
+- Fixed VoNR, VoWiFi, enhanced-data-icon, and other Root SIM controls replacing
+  one another when changed separately.
+- Root mode now saves one complete CarrierConfig profile per SIM and restores
+  it after reboot, user unlock, app update, or Root service reconnect.
+- **Restore Google defaults** also clears the saved Root profile.
+- Shizuku remains session-only and may reset after reboot, as intended.
 
 ### [1.0.5](https://github.com/barrylk/Pixel-IMS-5G/releases/tag/v1.0.5) — small update
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         // Every Tensor Pixel (Pixel 6 and newer) launched on Android 12 / API 31 or later.
         minSdk 31
         targetSdk 36
-        versionCode 25
-        versionName "1.0.5"
+        versionCode 26
+        versionName "1.0.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <queries>
         <package android:name="app.grapheneos.apps" />
@@ -104,6 +105,16 @@
             android:permission="android.permission.SEND_DOWNLOAD_COMPLETED_INTENTS">
             <intent-filter>
                 <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />
+            </intent-filter>
+        </receiver>
+        <receiver
+            android:name=".RootCarrierConfigBootReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.USER_UNLOCKED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/Moder.kt
@@ -912,7 +912,7 @@ class SubscriptionModer(
         // the force override afterwards.
         runCatching { restartIMSRegistration() }.onFailure { failedGates += "IMS restart" }
         runCatching {
-            publishBundle {
+            publishBundle(persistForRoot = false) {
                 it.putIntArray(
                     CarrierConfigManager.KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY,
                     intArrayOf(
@@ -970,10 +970,12 @@ class SubscriptionModer(
             }
         }
         restored = runCatching {
-            updateCarrierConfig(
-                CarrierConfigManager.KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY,
-                decode(prefs.getString(ROOT_FORCE_NR_AVAIL_PREFIX + subscriptionId, "")),
-            )
+            publishBundle(persistForRoot = false) {
+                it.putIntArray(
+                    CarrierConfigManager.KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY,
+                    decode(prefs.getString(ROOT_FORCE_NR_AVAIL_PREFIX + subscriptionId, "")),
+                )
+            }
             setBandSelectionInternal(
                 decode(prefs.getString(ROOT_FORCE_LTE_BANDS_PREFIX + subscriptionId, "")),
                 decode(prefs.getString(ROOT_FORCE_NR_BANDS_PREFIX + subscriptionId, "")),
@@ -1557,10 +1559,20 @@ class SubscriptionModer(
         }
     }
 
-    private fun publishBundle(fn: (Bundle) -> Unit) {
-        val overrideBundle = Bundle()
-        fn(overrideBundle)
-        this.overrideConfig(overrideBundle)
+    private fun publishBundle(
+        persistForRoot: Boolean = true,
+        fn: (Bundle) -> Unit,
+    ) {
+        val delta = Bundle()
+        fn(delta)
+        if (PrivilegeManager.activeMode == PrivilegeMode.ROOT) {
+            val store = RootCarrierConfigStore(context)
+            val merged = store.merge(subscriptionId, delta)
+            this.overrideConfig(merged)
+            if (persistForRoot) store.save(subscriptionId, merged)
+        } else {
+            this.overrideConfig(delta)
+        }
     }
 
     fun updateCarrierConfig(
@@ -1629,7 +1641,17 @@ class SubscriptionModer(
 
     fun clearCarrierConfig() {
         this.overrideConfig(null)
+        RootCarrierConfigStore(context).clear(subscriptionId)
     }
+
+    internal fun reapplyPersistedRootCarrierConfig(): Boolean =
+        runCatching {
+            check(PrivilegeManager.activeMode == PrivilegeMode.ROOT && PrivilegeManager.isRootReady())
+            val store = RootCarrierConfigStore(context)
+            if (!store.hasProfile(subscriptionId)) return true
+            this.overrideConfig(store.load(subscriptionId))
+            true
+        }.onFailure { Log.e(TAG, "Unable to reapply saved Root CarrierConfig", it) }.getOrDefault(false)
 
     fun restartIMSRegistration() {
         val telephony = this.loadCachedInterface { telephony }

--- a/app/src/main/java/dev/bluehouse/enablevolte/PrivilegeManager.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/PrivilegeManager.kt
@@ -130,9 +130,13 @@ object PrivilegeManager {
         }
     }
 
-    fun connectRoot(context: Context, result: (Boolean, String?) -> Unit) {
+    fun connectRoot(
+        context: Context,
+        reapplyPersistedConfig: Boolean = true,
+        result: (Boolean, String?) -> Unit,
+    ) {
         if (isRootReady()) {
-            result(true, null)
+            completeRootConnection(context, reapplyPersistedConfig, result)
             return
         }
         if (rootConnection != null) {
@@ -145,7 +149,11 @@ object PrivilegeManager {
                 val ready = isRootReady()
                 Log.i(TAG, "Root service connected: component=$name ready=$ready")
                 if (!ready) rootBridge = null
-                result(ready, if (ready) null else "The root service did not start as UID 0")
+                if (ready) {
+                    completeRootConnection(context, reapplyPersistedConfig, result)
+                } else {
+                    result(ready, if (ready) null else "The root service did not start as UID 0")
+                }
             }
 
             override fun onServiceDisconnected(name: ComponentName) {
@@ -180,6 +188,27 @@ object PrivilegeManager {
             rootConnection = null
             result(false, it.message ?: "Unable to request root access")
         }
+    }
+
+    private fun completeRootConnection(
+        context: Context,
+        reapplyPersistedConfig: Boolean,
+        result: (Boolean, String?) -> Unit,
+    ) {
+        if (!reapplyPersistedConfig) {
+            result(true, null)
+            return
+        }
+        Thread {
+            val reapplied = runCatching {
+                RootCarrierConfigPersistence.reapplyAll(context.applicationContext)
+            }.onFailure {
+                Log.w(TAG, "Unable to reapply the saved Root CarrierConfig profile", it)
+            }.getOrDefault(false)
+            context.mainExecutor.execute {
+                result(true, if (reapplied) null else "The saved Root SIM profile could not be fully reapplied")
+            }
+        }.start()
     }
 
     fun disconnectRoot() {

--- a/app/src/main/java/dev/bluehouse/enablevolte/ReleaseChangelog.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/ReleaseChangelog.kt
@@ -21,6 +21,28 @@ data class InstalledChangelog(
 object ReleaseChangelogCatalog {
     fun forVersion(version: String): InstalledChangelog? =
         when (version.removePrefix("v")) {
+            "1.0.6" ->
+                InstalledChangelog(
+                    version = "1.0.6",
+                    items =
+                        listOf(
+                            ChangelogItem(
+                                title = "Small bug fixes",
+                                detail = "Root SIM Config choices now stay together instead of later VoNR, VoWiFi, or enhanced-data-icon changes replacing earlier choices.",
+                                tone = ChangelogTone.FIX,
+                            ),
+                            ChangelogItem(
+                                title = "Persistent Root profiles",
+                                detail = "The app saves one complete profile per SIM and restores it after reboot, user unlock, app update, or Root service reconnect.",
+                                tone = ChangelogTone.IMPROVEMENT,
+                            ),
+                            ChangelogItem(
+                                title = "Safe reset behavior",
+                                detail = "Restore Google defaults also removes the saved Root profile. Shizuku controls remain session-only and may reset after reboot.",
+                                tone = ChangelogTone.IMPORTANT,
+                            ),
+                        ),
+                )
             "1.0.5" ->
                 InstalledChangelog(
                     version = "1.0.5",

--- a/app/src/main/java/dev/bluehouse/enablevolte/RootCarrierConfigPersistence.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/RootCarrierConfigPersistence.kt
@@ -1,0 +1,63 @@
+package dev.bluehouse.enablevolte
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal object RootCarrierConfigPersistence {
+    fun reapplyAll(context: Context): Boolean {
+        if (PrivilegeManager.activeMode != PrivilegeMode.ROOT || !PrivilegeManager.isRootReady()) return false
+        val carrierModer = CarrierModer(context)
+        return carrierModer.subscriptions
+            .filter { RootCarrierConfigStore(context).hasProfile(it.subscriptionId) }
+            .all { SubscriptionModer(context, it.subscriptionId).reapplyPersistedRootCarrierConfig() }
+    }
+
+    fun schedule(context: Context, delaySeconds: Long) {
+        if (PrivilegeManager.selectedMode(context) != PrivilegeMode.ROOT) return
+        val request = OneTimeWorkRequestBuilder<RootCarrierConfigPersistenceWorker>()
+            .setInitialDelay(delaySeconds, TimeUnit.SECONDS)
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            WORK_NAME,
+            ExistingWorkPolicy.REPLACE,
+            request,
+        )
+    }
+
+    private const val WORK_NAME = "root_carrier_config_persistence"
+}
+
+class RootCarrierConfigPersistenceWorker(
+    appContext: Context,
+    workerParams: WorkerParameters,
+) : Worker(appContext, workerParams) {
+    override fun doWork(): Result {
+        if (PrivilegeManager.selectedMode(applicationContext) != PrivilegeMode.ROOT) return Result.success()
+        PrivilegeManager.activate(applicationContext, PrivilegeMode.ROOT)
+
+        val completed = CountDownLatch(1)
+        val applied = AtomicBoolean(false)
+        PrivilegeManager.connectRoot(applicationContext, reapplyPersistedConfig = false) { ready, _ ->
+            if (ready) applied.set(RootCarrierConfigPersistence.reapplyAll(applicationContext))
+            completed.countDown()
+        }
+        if (!completed.await(25, TimeUnit.SECONDS)) return Result.retry()
+        return if (applied.get()) Result.success() else if (runAttemptCount < 2) Result.retry() else Result.failure()
+    }
+}
+
+class RootCarrierConfigBootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val delay = if (intent.action == Intent.ACTION_MY_PACKAGE_REPLACED) 3L else 20L
+        RootCarrierConfigPersistence.schedule(context.applicationContext, delay)
+    }
+}

--- a/app/src/main/java/dev/bluehouse/enablevolte/RootCarrierConfigStore.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/RootCarrierConfigStore.kt
@@ -1,0 +1,125 @@
+package dev.bluehouse.enablevolte
+
+import android.content.Context
+import android.os.Bundle
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+/**
+ * Stores the complete Root CarrierConfig profile per subscription. CarrierConfig overrideConfig
+ * replaces the previous override bundle; retaining individual toggle calls would therefore make
+ * the newest control silently discard every earlier one.
+ *
+ * Shizuku never writes this store. Its overrides intentionally remain session-only.
+ */
+internal class RootCarrierConfigStore(context: Context) {
+    private val preferences = context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
+
+    fun hasProfile(subscriptionId: Int): Boolean =
+        preferences.all.keys.any { it.startsWith(prefix(subscriptionId)) }
+
+    fun load(subscriptionId: Int): Bundle {
+        val result = Bundle()
+        val keyPrefix = prefix(subscriptionId)
+        preferences.all.forEach { (storedKey, rawValue) ->
+            if (!storedKey.startsWith(keyPrefix)) return@forEach
+            val carrierKey = storedKey.removePrefix(keyPrefix)
+            val decoded = RootCarrierConfigCodec.decode(rawValue as? String ?: return@forEach) ?: return@forEach
+            put(result, carrierKey, decoded)
+        }
+        return result
+    }
+
+    fun merge(subscriptionId: Int, delta: Bundle): Bundle =
+        load(subscriptionId).apply {
+            delta.keySet().forEach { key ->
+                delta.get(key)?.let { put(this, key, it) }
+            }
+        }
+
+    fun save(subscriptionId: Int, profile: Bundle) {
+        val keyPrefix = prefix(subscriptionId)
+        val editor = preferences.edit()
+        preferences.all.keys.filter { it.startsWith(keyPrefix) }.forEach { editor.remove(it) }
+        profile.keySet().forEach { key ->
+            profile.get(key)?.let { value ->
+                RootCarrierConfigCodec.encode(value)?.let { editor.putString(keyPrefix + key, it) }
+            }
+        }
+        editor.commit()
+    }
+
+    fun clear(subscriptionId: Int) {
+        val keyPrefix = prefix(subscriptionId)
+        val editor = preferences.edit()
+        preferences.all.keys.filter { it.startsWith(keyPrefix) }.forEach { editor.remove(it) }
+        editor.commit()
+    }
+
+    private fun prefix(subscriptionId: Int) = "sub_${subscriptionId}_"
+
+    private fun put(bundle: Bundle, key: String, value: Any) {
+        when (value) {
+            is Boolean -> bundle.putBoolean(key, value)
+            is Int -> bundle.putInt(key, value)
+            is Long -> bundle.putLong(key, value)
+            is String -> bundle.putString(key, value)
+            is IntArray -> bundle.putIntArray(key, value)
+            is BooleanArray -> bundle.putBooleanArray(key, value)
+            is LongArray -> bundle.putLongArray(key, value)
+            is Array<*> -> if (value.all { it is String }) {
+                @Suppress("UNCHECKED_CAST")
+                bundle.putStringArray(key, value as Array<String>)
+            }
+        }
+    }
+
+    companion object {
+        private const val PREFERENCES = "pixel_ims_root_carrier_config"
+    }
+}
+
+internal object RootCarrierConfigCodec {
+    private val encoder = Base64.getUrlEncoder().withoutPadding()
+    private val decoder = Base64.getUrlDecoder()
+
+    fun encode(value: Any): String? =
+        when (value) {
+            is Boolean -> "bool:${if (value) 1 else 0}"
+            is Int -> "int:$value"
+            is Long -> "long:$value"
+            is String -> "string:${encodeString(value)}"
+            is IntArray -> "ints:${value.joinToString(",")}"
+            is BooleanArray -> "bools:${value.joinToString(",") { if (it) "1" else "0" }}"
+            is LongArray -> "longs:${value.joinToString(",")}"
+            is Array<*> -> if (value.all { it is String }) {
+                "strings:${value.joinToString(",") { encodeString(it as String) }}"
+            } else {
+                null
+            }
+            else -> null
+        }
+
+    fun decode(encoded: String): Any? =
+        runCatching {
+            val type = encoded.substringBefore(':')
+            val value = encoded.substringAfter(':', "")
+            when (type) {
+                "bool" -> value == "1"
+                "int" -> value.toInt()
+                "long" -> value.toLong()
+                "string" -> decodeString(value)
+                "ints" -> if (value.isBlank()) intArrayOf() else value.split(',').map(String::toInt).toIntArray()
+                "bools" -> if (value.isBlank()) booleanArrayOf() else value.split(',').map { it == "1" }.toBooleanArray()
+                "longs" -> if (value.isBlank()) longArrayOf() else value.split(',').map(String::toLong).toLongArray()
+                "strings" -> if (value.isBlank()) emptyArray<String>() else value.split(',').map(::decodeString).toTypedArray()
+                else -> null
+            }
+        }.getOrNull()
+
+    private fun encodeString(value: String): String =
+        encoder.encodeToString(value.toByteArray(StandardCharsets.UTF_8))
+
+    private fun decodeString(value: String): String =
+        String(decoder.decode(value), StandardCharsets.UTF_8)
+}

--- a/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
+++ b/app/src/main/java/dev/bluehouse/enablevolte/pages/Config.kt
@@ -188,6 +188,22 @@ fun Config(
                     Text(stringResource(R.string.bands))
                 }
             }
+            Text(
+                text = stringResource(
+                    if (PrivilegeManager.activeMode == PrivilegeMode.ROOT) {
+                        R.string.root_sim_config_persistence
+                    } else {
+                        R.string.shizuku_sim_config_persistence
+                    },
+                ),
+                color = if (PrivilegeManager.activeMode == PrivilegeMode.ROOT) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(top = 12.dp),
+            )
             HeaderText(text = stringResource(R.string.feature_toggles))
             RadioSelectPropertyView(
                 label = stringResource(R.string.nr_architecture),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,8 @@
     <string name="sim_config">SIM Config</string>
     <string name="control_center">Controls</string>
     <string name="control_center_description">Monitoring is read-only and separate. Choose a SIM below to open every IMS, 5G, LTE+, radio, CarrierConfig, expert, and band control.</string>
+    <string name="root_sim_config_persistence">Root persistence is active. SIM Config choices are saved per SIM and restored after reboot.</string>
+    <string name="shizuku_sim_config_persistence">Shizuku SIM Config changes are session-only and may reset after reboot.</string>
     <string name="controls_no_sim">No active SIM is available. Return to Home and confirm privileged access.</string>
     <string name="controls_safety_note">Use Automatic/NSA preference for normal use. SA-only and manual bands can remove calls, SMS, or data where the selected network is unavailable.</string>
     <string name="ims_controls_summary">VoLTE, VoWiFi, VoNR, NSA/SA architecture, radio mode, IMS restart, CarrierConfig, expert settings, and reset controls.</string>

--- a/app/src/test/java/dev/bluehouse/enablevolte/ReleaseChangelogTest.kt
+++ b/app/src/test/java/dev/bluehouse/enablevolte/ReleaseChangelogTest.kt
@@ -8,11 +8,11 @@ import org.junit.Test
 class ReleaseChangelogTest {
     @Test
     fun currentReleaseHasStructuredHighlightedItems() {
-        val changelog = ReleaseChangelogCatalog.forVersion("v1.0.5")
+        val changelog = ReleaseChangelogCatalog.forVersion("v1.0.6")
 
         assertNotNull(changelog)
-        assertEquals("1.0.5", changelog?.version)
-        assertTrue(changelog.orEmptyItems().any { it.title == "VoLTE Fix" })
+        assertEquals("1.0.6", changelog?.version)
+        assertTrue(changelog.orEmptyItems().any { it.title == "Small bug fixes" })
     }
 
     @Test

--- a/app/src/test/java/dev/bluehouse/enablevolte/RootCarrierConfigCodecTest.kt
+++ b/app/src/test/java/dev/bluehouse/enablevolte/RootCarrierConfigCodecTest.kt
@@ -1,0 +1,28 @@
+package dev.bluehouse.enablevolte
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RootCarrierConfigCodecTest {
+    @Test
+    fun roundTripsEveryCarrierConfigType() {
+        assertEquals(true, roundTrip(true))
+        assertEquals(42, roundTrip(42))
+        assertEquals(9_000_000_000L, roundTrip(9_000_000_000L))
+        assertEquals("IMS value: ශ්‍රී ලංකා", roundTrip("IMS value: ශ්‍රී ලංකා"))
+        assertArrayEquals(intArrayOf(1, 2, 3), roundTrip(intArrayOf(1, 2, 3)) as IntArray)
+        assertArrayEquals(booleanArrayOf(true, false, true), roundTrip(booleanArrayOf(true, false, true)) as BooleanArray)
+        assertArrayEquals(longArrayOf(1L, 5L), roundTrip(longArrayOf(1L, 5L)) as LongArray)
+        assertArrayEquals(arrayOf("NSA", "SA", "value,with,comma"), roundTrip(arrayOf("NSA", "SA", "value,with,comma")) as Array<*>)
+    }
+
+    @Test
+    fun rejectsUnknownOrCorruptValues() {
+        assertEquals(null, RootCarrierConfigCodec.decode("unknown:value"))
+        assertEquals(null, RootCarrierConfigCodec.decode("int:not-a-number"))
+    }
+
+    private fun roundTrip(value: Any): Any? =
+        RootCarrierConfigCodec.decode(requireNotNull(RootCarrierConfigCodec.encode(value)))
+}

--- a/app/src/test/java/dev/bluehouse/enablevolte/UpdateManagerTest.kt
+++ b/app/src/test/java/dev/bluehouse/enablevolte/UpdateManagerTest.kt
@@ -16,5 +16,7 @@ class UpdateManagerTest {
         assertFalse(UpdateManager.isNewer("v1.0.4r", "1.0.4r"))
         assertTrue(UpdateManager.isNewer("1.0.5", "1.0.4r"))
         assertFalse(UpdateManager.isNewer("1.0.4r", "1.0.5"))
+        assertTrue(UpdateManager.isNewer("1.0.6", "1.0.5"))
+        assertFalse(UpdateManager.isNewer("1.0.5", "1.0.6"))
     }
 }


### PR DESCRIPTION
## Small bug fixes - v1.0.6

### What changed
- merges Root CarrierConfig toggles into one complete per-SIM profile
- saves Root profiles locally and reapplies them after reboot, user unlock, app update, or Root reconnect
- keeps Shizuku overrides session-only
- clears the saved profile when Google defaults are restored
- adds the in-app 1.0.6 What’s New cards, README changelog, and GitHub release notes

### Root cause
Android CarrierConfig overrides replace the previous override bundle. Sending each toggle as a separate one-key bundle caused later VoNR, VoWiFi, and enhanced-data-icon choices to silently discard earlier choices.

### Validation
- `:app:testDebugUnitTest` passed
- signed `:app:assembleRelease` passed
- package verified as `com.nirmala.pixel5gims`, version 1.0.6, code 26
- APK signing SHA-256 verified as `784be02ecb5b5144008282db33e61ba285dbfcd508ff834e0905f7941b3872c9`
- physical rooted Pixel 7 Pro reboot test confirmed the saved SIM 2 VoNR profile was reapplied as one merged bundle